### PR TITLE
feat(java): squeeze out last performance

### DIFF
--- a/java/src/main/java/solver/SHA2.java
+++ b/java/src/main/java/solver/SHA2.java
@@ -1,32 +1,8 @@
 package solver;
 
-
-import java.lang.invoke.MethodHandles;
-import java.lang.invoke.VarHandle;
-import java.nio.ByteOrder;
-
 abstract class SHA2 {
-    static final int[] ROUND_CONSTS = {
-            0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5,
-            0x3956c25b, 0x59f111f1, 0x923f82a4, 0xab1c5ed5,
-            0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3,
-            0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174,
-            0xe49b69c1, 0xefbe4786, 0x0fc19dc6, 0x240ca1cc,
-            0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
-            0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7,
-            0xc6e00bf3, 0xd5a79147, 0x06ca6351, 0x14292967,
-            0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13,
-            0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85,
-            0xa2bfe8a1, 0xa81a664b, 0xc24b8b70, 0xc76c51a3,
-            0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070,
-            0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5,
-            0x391c0cb3, 0x4ed8aa4a, 0x5b9cca4f, 0x682e6ff3,
-            0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208,
-            0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2
-    };
-    private static final VarHandle INT_ARRAY
-            = MethodHandles.byteArrayViewVarHandle(int[].class,
-            ByteOrder.BIG_ENDIAN);
+    protected final int[] state = new int[8];
+    protected final int[] W = new int[64];
 
     static byte[] buffer(int len) {
         byte[] buf = new byte[64];
@@ -34,10 +10,23 @@ abstract class SHA2 {
         return buf;
     }
 
-    protected final int[] state = new int[8];
-    protected final int[] W = new int[64];
+    static int[] toState(byte[] hash) {
+        if (hash.length != 32) {
+            throw new IllegalArgumentException("Bad hash length for sha256");
+        }
+        int[] state = new int[8];
+        state[0] = fromBytes(hash, 0);
+        state[1] = fromBytes(hash, 4);
+        state[2] = fromBytes(hash, 8);
+        state[3] = fromBytes(hash, 12);
+        state[4] = fromBytes(hash, 16);
+        state[5] = fromBytes(hash, 20);
+        state[6] = fromBytes(hash, 24);
+        state[7] = fromBytes(hash, 28);
+        return state;
+    }
 
-    public final void digest(byte[] in, int inLen, byte[] out) {
+    public final void digest(byte[] in, int inLen) {
         int[] state = this.state;
         state[0] = 0x6a09e667;
         state[1] = 0xbb67ae85;
@@ -47,42 +36,17 @@ abstract class SHA2 {
         state[5] = 0x9b05688c;
         state[6] = 0x1f83d9ab;
         state[7] = 0x5be0cd19;
-        implDigest(W, state, in, inLen, out);
+        // int bitsProcessed = inLen << 3;
+        // SHA2.i2bBig4(bitsProcessed, in, 60);
+        // bitsProcessed for ipv4 address would be always
+        // less than 255 bits. (15 << 3) == 120
+        in[63] = (byte) (inLen << 3);
+        implCompress0(W, state, in);
     }
 
-    abstract void implDigest(int[] W, int[] state, byte[] in, int inLen, byte[] out);
+    abstract void implCompress0(int[] W, int[] state, byte[] buf);
 
-    static void b2iBig64(byte[] in, int[] out) {
-        out[0] = (int) INT_ARRAY.get(in, 0);
-        out[1] = (int) INT_ARRAY.get(in, 4);
-        out[2] = (int) INT_ARRAY.get(in, 8);
-        out[3] = (int) INT_ARRAY.get(in, 12);
-        out[4] = (int) INT_ARRAY.get(in, 16);
-        out[5] = (int) INT_ARRAY.get(in, 20);
-        out[6] = (int) INT_ARRAY.get(in, 24);
-        out[7] = (int) INT_ARRAY.get(in, 28);
-        out[8] = (int) INT_ARRAY.get(in, 32);
-        out[9] = (int) INT_ARRAY.get(in, 36);
-        out[10] = (int) INT_ARRAY.get(in, 40);
-        out[11] = (int) INT_ARRAY.get(in, 44);
-        out[12] = (int) INT_ARRAY.get(in, 48);
-        out[13] = (int) INT_ARRAY.get(in, 52);
-        out[14] = (int) INT_ARRAY.get(in, 56);
-        out[15] = (int) INT_ARRAY.get(in, 60);
-    }
-
-    static void i2bBig(int[] in, byte[] out) {
-        INT_ARRAY.set(out, 0, in[0]);
-        INT_ARRAY.set(out, 4, in[1]);
-        INT_ARRAY.set(out, 8, in[2]);
-        INT_ARRAY.set(out, 12, in[3]);
-        INT_ARRAY.set(out, 16, in[4]);
-        INT_ARRAY.set(out, 20, in[5]);
-        INT_ARRAY.set(out, 24, in[6]);
-        INT_ARRAY.set(out, 28, in[7]);
-    }
-
-    static void i2bBig4(int val, byte[] out, int index) {
-        INT_ARRAY.set(out, index, val);
+    private static int fromBytes(byte[] b, int off) {
+        return b[off] << 24 | (b[off + 1] & 0xff) << 16 | (b[off + 2] & 0xff) << 8 | (b[off + 3] & 0xff);
     }
 }

--- a/java/src/main/java/solver/SHA2NoIntrinsics.java
+++ b/java/src/main/java/solver/SHA2NoIntrinsics.java
@@ -1,19 +1,33 @@
 package solver;
 
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
+import java.nio.ByteOrder;
+
 final class SHA2NoIntrinsics extends SHA2 {
+    private static final VarHandle INT_ARRAY = MethodHandles.byteArrayViewVarHandle(int[].class, ByteOrder.BIG_ENDIAN);
+    private static final int[] ROUND_CONSTS = {
+            0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5,
+            0x3956c25b, 0x59f111f1, 0x923f82a4, 0xab1c5ed5,
+            0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3,
+            0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174,
+            0xe49b69c1, 0xefbe4786, 0x0fc19dc6, 0x240ca1cc,
+            0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
+            0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7,
+            0xc6e00bf3, 0xd5a79147, 0x06ca6351, 0x14292967,
+            0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13,
+            0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85,
+            0xa2bfe8a1, 0xa81a664b, 0xc24b8b70, 0xc76c51a3,
+            0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070,
+            0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5,
+            0x391c0cb3, 0x4ed8aa4a, 0x5b9cca4f, 0x682e6ff3,
+            0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208,
+            0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2
+    };
 
-    void implDigest(int[] W, int[] state, byte[] in, int inLen, byte[] out) {
-        int bitsProcessed = inLen << 3;
-
-        SHA2.i2bBig4(0, in, 56);
-        SHA2.i2bBig4(bitsProcessed, in, 60);
-        implCompress0(W, state, in);
-
-        SHA2.i2bBig(state, out);
-    }
-
-    private static void implCompress0(int[] W, int[] state, byte[] buf) {
-        SHA2.b2iBig64(buf, W);
+    @Override
+    void implCompress0(int[] W, int[] state, byte[] buf) {
+        b2iBig64(buf, W);
         for (int t = 16; t < 64; t++) {
             int W_t2 = W[t - 2];
             int W_t15 = W[t - 15];
@@ -40,7 +54,7 @@ final class SHA2NoIntrinsics extends SHA2 {
         int g = state[6];
         int h = state[7];
 
-        int[] ROUND_CONSTS = SHA2.ROUND_CONSTS;
+        int[] ROUND_CONSTS = SHA2NoIntrinsics.ROUND_CONSTS;
         for (int i = 0; i < 64; i++) {
             int sigma0_a =
                     ((a >>> 2) | (a << 30)) ^
@@ -76,5 +90,24 @@ final class SHA2NoIntrinsics extends SHA2 {
         state[5] += f;
         state[6] += g;
         state[7] += h;
+    }
+
+    private static void b2iBig64(byte[] in, int[] out) {
+        out[0] = (int) INT_ARRAY.get(in, 0);
+        out[1] = (int) INT_ARRAY.get(in, 4);
+        out[2] = (int) INT_ARRAY.get(in, 8);
+        out[3] = (int) INT_ARRAY.get(in, 12);
+        out[4] = (int) INT_ARRAY.get(in, 16);
+        out[5] = (int) INT_ARRAY.get(in, 20);
+        out[6] = (int) INT_ARRAY.get(in, 24);
+        out[7] = (int) INT_ARRAY.get(in, 28);
+        out[8] = (int) INT_ARRAY.get(in, 32);
+        out[9] = (int) INT_ARRAY.get(in, 36);
+        out[10] = (int) INT_ARRAY.get(in, 40);
+        out[11] = (int) INT_ARRAY.get(in, 44);
+        out[12] = (int) INT_ARRAY.get(in, 48);
+        out[13] = (int) INT_ARRAY.get(in, 52);
+        out[14] = (int) INT_ARRAY.get(in, 56);
+        out[15] = (int) INT_ARRAY.get(in, 60);
     }
 }

--- a/java/src/main/java/solver/SHA2WithIntrinsics.java
+++ b/java/src/main/java/solver/SHA2WithIntrinsics.java
@@ -49,17 +49,11 @@ final class SHA2WithIntrinsics extends SHA2 {
     }
 
     @Override
-    void implDigest(int[] W, int[] state, byte[] in, int inLen, byte[] out) {
-        int bitsProcessed = inLen << 3;
-
-        SHA2.i2bBig4(0, in, 56);
-        SHA2.i2bBig4(bitsProcessed, in, 60);
+    void implCompress0(int[] W, int[] state, byte[] buf) {
         try {
-            MH_COMPRESS.invokeExact(impl, in, 0);
+            MH_COMPRESS.invokeExact(impl, buf, 0);
         } catch (Throwable t) {
             throw new RuntimeException(t);
         }
-
-        SHA2.i2bBig(state, out);
     }
 }


### PR DESCRIPTION
This change makes the solver operate on sha state directly, without conversions